### PR TITLE
Barklem collisions now use the correct l-value

### DIFF
--- a/zeeman.c
+++ b/zeeman.c
@@ -31,7 +31,6 @@ extern Atmosphere atmos;
 extern InputData input;
 extern char messageStr[];
 
-
 /* ------- begin -------------------------- determinate.c ----------- */
 
 bool_t determinate(char *label, double g, int *n, double *S, int *L,


### PR DESCRIPTION
The implementation of Barklem's recipes for van der Waals damping was using the wrong value of the orbital in order to decide what table to use. I have adapted the code for lines in active atoms and RLK lines so that the Barklem colisional cross-sections are interpolated using the correct l-value. Additionally, the user can also replace the standatd Kurucz vdW constant with Barklem's sigma.alpha (eg., 852.243).