### PR TITLE
phi_V and psi_V were not multiplied by the isotopic fraction

### DIFF
--- a/profile.c
+++ b/profile.c
@@ -283,7 +283,7 @@ void Profile(AtomicLine *line)
 		  phi_delta * sin2_gamma * atmos.cos_2chi[mu][k] * sv[k];
 		phi_U[k] +=
 		  phi_delta * sin2_gamma * atmos.sin_2chi[mu][k] * sv[k];
-		phi_V[k] += sign *
+		phi_V[k] += sign * line->c_fraction[n] * 
 		  0.5*(phi_sp - phi_sm) * atmos.cos_gamma[mu][k] * sv[k];
 
 		if (input.magneto_optical) {
@@ -295,7 +295,7 @@ void Profile(AtomicLine *line)
 		    psi_delta * sin2_gamma * atmos.cos_2chi[mu][k] * sv[k];
 		  psi_U[k] +=
 		    psi_delta * sin2_gamma * atmos.sin_2chi[mu][k] * sv[k];
-		  psi_V[k] += sign *
+		  psi_V[k] += sign * line->c_fraction[n] * 
 		    0.5 * (psi_sp - psi_sm) * atmos.cos_gamma[mu][k] * sv[k];
 		}
 	      }


### PR DESCRIPTION
Hi Han,
it seems that in profile.c, the phi_V and psi_V components are missing the scaling with the isotopic fraction. I have added the scaling, otherwise the results are crazy when the magnetic field is non-zero (and running with isotopic-splitting).

Additionally, the original reference given in the code (van Ballegooijen 1987) has the modification of the sign of U somewhat different. In the code, the "sign" variable is multiplying phi_Q, phy_V, psi_Q an psi_V. But according to the book (eq. 2.9, 2.18, 2.20) it should affect phi_U, psi_Q and psi_V. I have not changed this part in this pull request, as I do not know if there was a reason for this.

Best regards!
Jaime